### PR TITLE
Allow downloading of static images

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -22,6 +22,7 @@ Requires the following software before beginning:
 - Python 3.4+
 - PostgreSQL 9.4+
 - Python virtualenv and virtualenvwrapper
+- PhantomJS 2.1+
 
 Create a new python virtual environment, we'll use the virtual environment name `orio-web` throughout the documentation. If you have [virtualenvwrapper](https://pypi.python.org/pypi/virtualenvwrapper/) installed, you can create a new environment using the command below (note that this requires you to specify the path for python 3, which is not the default python with many installations):
 

--- a/project/assets/AnalysisVisual/AnalysisOverview.js
+++ b/project/assets/AnalysisVisual/AnalysisOverview.js
@@ -3,12 +3,15 @@ import $ from 'jquery';
 import d3 from 'd3';
 import {interpolateInferno} from 'd3-scale';
 import {interpolateRdYlBu} from 'd3-scale-chromatic';
+import React from 'react';
+import ReactDOM from 'react-dom';
 
 import {heatmapColorScale} from './utils';
 import ScatterplotModal from './ScatterplotModal';
 import SortVectorScatterplotModal from './SortVectorScatterplotModal';
 import HeatmapLegend from './HeatmapLegend';
 import Loader from './Loader';
+import SaveAsImage from './components/SaveAsImage';
 
 
 class AnalysisOverview{
@@ -19,6 +22,17 @@ class AnalysisOverview{
         this.analysisOverviewInitURL = function(id) {
             return (`/dashboard/api/analysis/${id}/analysis_overview/`);
         };
+
+        this.renderDownloadBtn();
+    }
+
+    renderDownloadBtn(){
+        let dl = $('<div>').css({
+            float: 'right',
+            'padding-top': '5px',
+        }).insertAfter(this.el);
+
+        ReactDOM.render(<SaveAsImage content={this.el.get(0)} />, dl.get(0));
     }
 
     renderContainers(){
@@ -75,6 +89,7 @@ class AnalysisOverview{
                 height: '20%',
                 width: '20%',
             }).appendTo(this.el);
+
     }
 
     drawHeatmap(data) {

--- a/project/assets/AnalysisVisual/FeatureClusteringOverview.js
+++ b/project/assets/AnalysisVisual/FeatureClusteringOverview.js
@@ -1,11 +1,13 @@
 import $ from 'jquery';
 import d3 from 'd3';
+import React from 'react';
+import ReactDOM from 'react-dom';
 
 import Loader from './Loader';
+import SaveAsImage from './components/SaveAsImage';
 import FeatureClusterDetailModal from './FeatureClusterDetailModal';
 import {interpolateRdYlBu} from 'd3-scale-chromatic';
 import {interpolateSpectral} from 'd3-scale-chromatic';
-
 import {heatmapColorScale} from './utils';
 
 
@@ -16,6 +18,15 @@ class FeatureClusteringOverview{
         this.id = window.analysisObjectID;
         this.colors = this.getColors();
         window.clustHeatmapOffset = {left:60};
+        this.renderDownloadBtn();
+    }
+
+    renderDownloadBtn(){
+        let dl = $('<div>').css({
+            float: 'right',
+            'padding-top': '5px',
+        }).insertAfter(this.el);
+        ReactDOM.render(<SaveAsImage content={this.el.get(0)} />, dl.get(0));
     }
 
     getColors(){

--- a/project/assets/AnalysisVisual/FeatureClusteringOverview.js
+++ b/project/assets/AnalysisVisual/FeatureClusteringOverview.js
@@ -70,6 +70,13 @@ class FeatureClusteringOverview{
             }
         }
 
+        // convert canvas to img
+        let img = $('<img>')
+        img.width = heatmap.width();
+        img.height = heatmap.height();
+        img.attr('src', heatmap.get(0).toDataURL());
+        heatmap.after(img).remove();
+
         var height = heatmap_col_tooltips.height(),
             width = heatmap_col_tooltips.width() - window.clustHeatmapOffset.left,
             col_number = data['col_names'].length;

--- a/project/assets/AnalysisVisual/IndividualHeatmap.js
+++ b/project/assets/AnalysisVisual/IndividualHeatmap.js
@@ -427,21 +427,20 @@ class IndividualHeatmap {
 
         this.modal_body.find('#heatmap_canvas').remove();
 
-        $('<canvas id="heatmap_canvas">')
-            .prop({
-                'height': this.heatmap_dim.h,
-                'width': this.heatmap_dim.w,
-            })
-            .css({
+        var canvas_css = {
                 'position': 'absolute',
                 'left': this.heatmap_dim.x,
                 'top': this.heatmap_dim.y,
-            })
-            .appendTo(this.modal_body);
+            },
+            canvas = $('<canvas id="heatmap_canvas">')
+                .prop({
+                    'height': this.heatmap_dim.h,
+                    'width': this.heatmap_dim.w,
+                })
+                .css(canvas_css)
+                .appendTo(this.modal_body);
 
-        var context = document.getElementById('heatmap_canvas')
-            .getContext('2d');
-
+        var context = canvas.get(0).getContext('2d');
         var scale_y = dim_y > data.length ? dim_y/data.length : 1;
         var scale_x = dim_x > data[0].length ? dim_x/data[0].length: 1;
 
@@ -466,6 +465,13 @@ class IndividualHeatmap {
                 context.fillRect(j,i,1,1);
             }
         }
+
+        // convert canvas to img
+        let img = $('<img>').css(canvas_css);
+        img.width = canvas.width();
+        img.height = canvas.height();
+        img.attr('src', canvas.get(0).toDataURL());
+        canvas.after(img).remove();
     }
 
     renderLoader(){

--- a/project/assets/AnalysisVisual/IndividualHeatmap.js
+++ b/project/assets/AnalysisVisual/IndividualHeatmap.js
@@ -2,12 +2,17 @@ import $ from 'jquery';
 import d3 from 'd3';
 import _ from 'underscore';
 
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import SaveAsImage from './components/SaveAsImage';
 import Loader from './Loader';
 
 
 class IndividualHeatmap {
 
-    constructor (id, matrix_names, matrix_ids, heatmap_name, modal_title, modal_body, sort_vector, analysis_id) {
+    constructor (id, matrix_names, matrix_ids, heatmap_name,
+                 modal_title, modal_body, sort_vector, analysis_id) {
         this.id = id;
         this.matrix_names = matrix_names;
         this.matrix_ids = matrix_ids;
@@ -50,6 +55,17 @@ class IndividualHeatmap {
             h: 0.15 * this.modal_dim.h,
             w: 0.335 * this.modal_dim.w,
         };
+
+        this.renderDownloadBtn();
+    }
+
+    renderDownloadBtn(){
+        let dl = $('<div>').css({
+            float: 'right',
+            'margin-right': '20px',
+            'margin-top': '-40px',
+        }).insertAfter(this.modal_body);
+        ReactDOM.render(<SaveAsImage content={this.modal_body} />, dl.get(0));
     }
 
     displayQuartilePValue(ad_p, kw_p) {

--- a/project/assets/AnalysisVisual/IndividualOverview.js
+++ b/project/assets/AnalysisVisual/IndividualOverview.js
@@ -1,9 +1,12 @@
 import _ from 'underscore';
 import $ from 'jquery';
 import d3 from 'd3';
+import React from 'react';
+import ReactDOM from 'react-dom';
 import {interpolateInferno} from 'd3-scale';
 import {interpolateRdYlBu} from 'd3-scale-chromatic';
 
+import SaveAsImage from './components/SaveAsImage';
 import {heatmapColorScale} from './utils';
 import HeatmapLegend from './HeatmapLegend';
 import IndividualHeatmap from './IndividualHeatmap';
@@ -15,6 +18,15 @@ class IndividualOverview {
     constructor(el, analysis_id) {
         this.el = el;
         this.id = window.analysisObjectID;
+        this.renderDownloadBtn();
+    }
+
+    renderDownloadBtn(){
+        let dl = $('<div>').css({
+            float: 'left',
+            'padding-top': '5px',
+        }).insertAfter(this.el);
+        ReactDOM.render(<SaveAsImage content={this.el.get(0)} />, dl.get(0));
     }
 
     individualOverviewInitURL(id) {

--- a/project/assets/AnalysisVisual/ScatterplotModal.js
+++ b/project/assets/AnalysisVisual/ScatterplotModal.js
@@ -5,6 +5,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import Loader from './Loader';
+import SaveAsImage from './components/SaveAsImage';
 
 
 class ScatterplotModal {
@@ -50,7 +51,10 @@ class ScatterplotModal {
                             </div>
                         </form>
                     </div>
-                    <div id="visual"></div>
+                    <div id="scmvisual"></div>
+                    <div style={{float: 'right', marginRight: 50}}>
+                        <SaveAsImage selector={'#scmvisual'} dropup={true} />
+                    </div>
                 </div>
             );
         };
@@ -74,7 +78,7 @@ class ScatterplotModal {
     }
 
     renderLoader(){
-        var par = this.modal_body.find('#visual');
+        var par = this.modal_body.find('#scmvisual');
         new Loader(par);
         this.loadingSpinner = par.find('.loadingSpinner');
         this.loadingSpinner.css({
@@ -104,7 +108,7 @@ class ScatterplotModal {
         // DOM objects
         var $parent = this.modal_body,
             $form = this.modal_body.find('#inputForm'),
-            $visual = this.modal_body.find('#visual');
+            $visual = this.modal_body.find('#scmvisual');
 
         // constants
         var margin = {top: 20, right: 40, bottom: 50, left: 80},

--- a/project/assets/AnalysisVisual/components/ClusterDetailBody.js
+++ b/project/assets/AnalysisVisual/components/ClusterDetailBody.js
@@ -4,6 +4,7 @@ import React from 'react';
 import {saveAs} from 'filesaver.js';
 
 import Loader from './Loader';
+import SaveAsImage from './SaveAsImage';
 import ClusterQuant from './ClusterQuant';
 
 import h from 'utils/helpers';
@@ -137,6 +138,9 @@ class ClusterDetailBody extends React.Component {
                         analysis_id={this.props.analysis_id}
                         k={this.props.k}
                         cluster_id={this.props.cluster_id}/>
+                    <div style={{float: 'right', marginRight: 75}}>
+                        <SaveAsImage selector={'#clusterQuant'} />
+                    </div>
                 </div>
             </div>
         </div>;

--- a/project/assets/AnalysisVisual/components/ClusterQuant.js
+++ b/project/assets/AnalysisVisual/components/ClusterQuant.js
@@ -113,7 +113,7 @@ class ClusterQuant extends React.Component {
     render() {
         var width = $('#ind_heatmap_modal_body').width() - 30;
         return (
-            <div className="container-fluid">
+            <div id='clusterQuant' className="container-fluid">
                 {this.renderSelector()}
                 {this.renderCharts(width)}
             </div>

--- a/project/assets/AnalysisVisual/components/SaveAsImage.js
+++ b/project/assets/AnalysisVisual/components/SaveAsImage.js
@@ -4,28 +4,38 @@ import React from 'react';
 
 class SaveAsImage extends React.Component {
 
+    constructor(){
+        super();
+        this.handlePngSubmit = this.handlePngSubmit.bind(this);
+        this.handlePdfSubmit = this.handlePdfSubmit.bind(this);
+    }
+
     getJqueryElement(){
         return (this.props.content)?
             $(this.props.content):
             $(this.props.selector);
     }
 
-    handlePngSubmit(){
+    handlePngSubmit(e){
+        e.preventDefault();
         let $el = this.getJqueryElement();
         this.refs.content.value = $el.html();
-        this.refs.width.value = $el.width() * 1.05;
-        this.refs.height.value = $el.height() * 1.05;
+        this.refs.width.value = parseInt($el.width() * 1.05);
+        this.refs.height.value = parseInt($el.height() * 1.05);
         this.refs.format.value = 'png';
         this.refs.form.submit();
+        return false;
     }
 
-    handlePdfSubmit(){
+    handlePdfSubmit(e){
+        e.preventDefault();
         let $el = this.getJqueryElement();
         this.refs.content.value = $el.html();
-        this.refs.width.value = $el.width() * 1.05;
-        this.refs.height.value = $el.height() * 1.05;
+        this.refs.width.value = parseInt($el.width() * 1.05);
+        this.refs.height.value = parseInt($el.height() * 1.05);
         this.refs.format.value = 'pdf';
         this.refs.form.submit();
+        return false;
     }
 
     render(){
@@ -47,9 +57,9 @@ class SaveAsImage extends React.Component {
                 <i className='fa fa-download'></i>
                 </button>
                 <ul className="dropdown-menu" style={{minWidth: 0}}>
-                    <li><a href='#' onClick={this.handlePngSubmit.bind(this)}>
+                    <li><a href='#' onClick={this.handlePngSubmit}>
                         <i className='fa fa-fixed fa-file-image-o'></i> PNG</a></li>
-                    <li><a href='#' onClick={this.handlePdfSubmit.bind(this)}>
+                    <li><a href='#' onClick={this.handlePdfSubmit}>
                         <i className='fa fa-fixed fa-file-pdf-o'></i> PDF</a></li>
                 </ul>
             </div>

--- a/project/assets/AnalysisVisual/components/SaveAsImage.js
+++ b/project/assets/AnalysisVisual/components/SaveAsImage.js
@@ -1,0 +1,66 @@
+import $ from 'jquery';
+import React from 'react';
+
+
+class SaveAsImage extends React.Component {
+
+    getJqueryElement(){
+        return (this.props.content)?
+            $(this.props.content):
+            $(this.props.selector);
+    }
+
+    handlePngSubmit(){
+        let $el = this.getJqueryElement();
+        this.refs.content.value = $el.html();
+        this.refs.width.value = $el.width() * 1.05;
+        this.refs.height.value = $el.height() * 1.05;
+        this.refs.format.value = 'png';
+        this.refs.form.submit();
+    }
+
+    handlePdfSubmit(){
+        let $el = this.getJqueryElement();
+        this.refs.content.value = $el.html();
+        this.refs.width.value = $el.width() * 1.05;
+        this.refs.height.value = $el.height() * 1.05;
+        this.refs.format.value = 'pdf';
+        this.refs.form.submit();
+    }
+
+    render(){
+        let classType = (this.props.dropup)? 'btn-group dropup': 'btn-group';
+        return <div>
+            <form className='hidden' ref='form' action="/phantom/rasterize/" method="post">
+                <select ref='format' name='format'>
+                    <option value='png'>png</option>
+                    <option value='pdf'>pdf</option>
+                </select>
+                <input ref='content' name='content'></input>
+                <input type="number" ref='width' name='width'></input>
+                <input type="number" ref='height' name='height'></input>
+            </form>
+            <div className={classType}>
+                <button type="button" className="btn btn-sm btn-default dropdown-toggle"
+                    data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+                    title="Download image of visualization">
+                <i className='fa fa-download'></i>
+                </button>
+                <ul className="dropdown-menu" style={{minWidth: 0}}>
+                    <li><a href='#' onClick={this.handlePngSubmit.bind(this)}>
+                        <i className='fa fa-fixed fa-file-image-o'></i> PNG</a></li>
+                    <li><a href='#' onClick={this.handlePdfSubmit.bind(this)}>
+                        <i className='fa fa-fixed fa-file-pdf-o'></i> PDF</a></li>
+                </ul>
+            </div>
+        </div>;
+    }
+}
+
+SaveAsImage.propTypes = {
+    content: React.PropTypes.instanceOf(window.HTMLElement),
+    selector: React.PropTypes.string,
+    dropup: React.PropTypes.bool,
+};
+
+export default SaveAsImage;

--- a/project/django_project/settings/base.py
+++ b/project/django_project/settings/base.py
@@ -217,4 +217,5 @@ WEBPACK_LOADER = {
     }
 }
 
+# assume phantomJS is available on PATH; else change to absolute location
 PHANTOMJS_PATH = 'phantomjs'

--- a/project/django_project/settings/base.py
+++ b/project/django_project/settings/base.py
@@ -107,6 +107,7 @@ INSTALLED_APPS = (
     'myuser',
     'staticpages',
     'analysis',
+    'phantom',
 )
 
 AUTH_USER_MODEL = 'myuser.User'
@@ -215,3 +216,5 @@ WEBPACK_LOADER = {
         'IGNORE': ['.+\.hot-update.js', '.+\.map']
     }
 }
+
+PHANTOMJS_PATH = 'phantomjs'

--- a/project/django_project/urls.py
+++ b/project/django_project/urls.py
@@ -31,6 +31,10 @@ urlpatterns = [
         include('myuser.urls',
                 namespace='user')),
 
+    url(r'^phantom/',
+        include('phantom.urls',
+                namespace='phantom')),
+
     url(r'^task-error/$',
         views.CeleryErrorTester.as_view(),
         name='celery'),

--- a/project/phantom/apps.py
+++ b/project/phantom/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class PhantomConfig(AppConfig):
+    name = 'phantom'

--- a/project/phantom/constants.py
+++ b/project/phantom/constants.py
@@ -1,0 +1,2 @@
+FORMATS = ('png', 'pdf')
+FORMAT_CHOICES = (('png', 'png'), ('pdf', 'pdf'),)

--- a/project/phantom/convert.py
+++ b/project/phantom/convert.py
@@ -1,0 +1,79 @@
+import logging
+import os
+import subprocess
+import tempfile
+
+from django.conf import settings
+from django.template.loader import render_to_string
+
+__all__ = ('Converter', )
+
+
+logger = logging.getLogger(__name__)
+
+
+class TempFileList(list):
+    # Maintains a list of temporary files and cleans up after itself
+
+    def get_tempfile(self, prefix='', suffix='.txt'):
+        fd, fn = tempfile.mkstemp(prefix=prefix, suffix=suffix)
+        os.close(fd)
+        self.append(fn)
+        return fn
+
+    def cleanup(self):
+        for fn in iter(self):
+            try:
+                os.remove(fn)
+            except OSError:
+                pass
+
+    def __del__(self):
+        self.cleanup()
+
+
+class Converter:
+
+    def __init__(self, static_path, format, html, width, height):
+        self.static_path = static_path
+        self.format = format
+        self.html = html
+        self.width = width
+        self.height = height
+        self.tempfiles = TempFileList()
+
+    def _to_html(self):
+        # return rendered html absolute filepath
+        fn = self.tempfiles.get_tempfile(suffix='.html')
+        html = render_to_string('phantom/base.html', dict(
+            static_path=self.static_path,
+            content=self.html,
+        ))
+        with open(fn, 'w') as f:
+            f.write(html)
+        return fn
+
+    def _rasterize(self, output_fn):
+        rasterize = os.path.join(
+            settings.PROJECT_PATH,
+            'phantom/js/rasterize.js')
+        html_fn = self._to_html()
+        commands = [
+            settings.PHANTOMJS_PATH, rasterize,
+            html_fn, output_fn,
+            str(self.width), str(self.height)
+        ]
+        subprocess.call(commands)
+
+    def convert(self):
+        content = None
+        try:
+            img = self.tempfiles.get_tempfile(suffix='.' + self.format)
+            self._rasterize(img)
+            with open(img, 'rb') as f:
+                content = f.read()
+        except Exception as e:
+            logger.error(e, exc_info=True)
+        finally:
+            self.tempfiles.cleanup()
+        return content

--- a/project/phantom/forms.py
+++ b/project/phantom/forms.py
@@ -1,0 +1,10 @@
+from django import forms
+
+from .constants import FORMAT_CHOICES
+
+
+class RasterizeForm(forms.Form):
+    format = forms.ChoiceField(choices=FORMAT_CHOICES)
+    content = forms.CharField()
+    width = forms.IntegerField(min_value=300)
+    height = forms.IntegerField(min_value=300)

--- a/project/phantom/js/rasterize.js
+++ b/project/phantom/js/rasterize.js
@@ -1,0 +1,56 @@
+"use strict";
+var page = require('webpage').create(),
+    system = require('system'),
+    address = system.args[1],
+    output = system.args[2],
+    width = parseInt(system.args[3]),
+    height = parseInt(system.args[4]),
+    renderTimeout = 3000,
+    renderAndExit = function(){
+        // Wait for animations, after viewport size change
+        window.setTimeout(function(){
+            page.render(output);
+            phantom.exit();
+        }, renderTimeout);
+    },
+    getPdf = function(){
+        renderAndExit();
+    },
+    getRasterization = function(){
+        page.zoomFactor = 1;
+        renderAndExit();
+    };
+
+var func = (output.substr(-4) === '.pdf') ? getPdf : getRasterization,
+    onPageReady = function(){
+        window.setTimeout(func, renderTimeout);
+    },
+    checkReadyState = function() {
+        // continue to check until ready-state is complete
+        setTimeout(function () {
+            var readyState = page.evaluate(function () {
+                return document.readyState;
+            });
+            if (readyState === 'complete') {
+                onPageReady();
+            } else {
+                checkReadyState();
+            }
+        });
+    },
+    onLoadFinished = function (status) {
+        // page loaded but other resources may not be complete
+        if (status === 'success') {
+            checkReadyState();
+        } else {
+            console.log('Unable to load the address!');
+            phantom.exit(1);
+        }
+    };
+
+page.viewportSize = {
+    width: width,
+    height: height,
+};
+
+page.open(address, onLoadFinished);

--- a/project/phantom/templates/phantom/base.html
+++ b/project/phantom/templates/phantom/base.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv='X-UA-Compatible' content='IE=Edge'></meta>
+    <meta charset="utf-8"></meta>
+    <meta name='viewport' content='width=device-width, initial-scale=1.0'></meta>
+
+    <!-- custom stylesheets for ORIO -->
+    <link rel='stylesheet' type='text/css'
+        href='{{static_path}}lib/css/bootstrap.min.css'>
+    <link rel="stylesheet" type="text/css" media="all"
+        href="{{static_path}}css/site.css">
+    <link rel="stylesheet" type="text/css" media="all"
+          href="{{static_path}}css/visuals.css">
+
+</head>
+<body>
+    <div id='rContent'>
+        {{content|safe}}
+    </div>
+</body>
+</html>

--- a/project/phantom/urls.py
+++ b/project/phantom/urls.py
@@ -1,0 +1,12 @@
+from django.conf.urls import url
+
+from . import views
+
+
+urlpatterns = [
+
+    url(r'^rasterize/$',
+        views.Rasterize.as_view(),
+        name='rasterize'),
+
+]

--- a/project/phantom/views.py
+++ b/project/phantom/views.py
@@ -1,4 +1,6 @@
-from django.views.generic import View
+import json
+
+from django.views.generic import FormView
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
 from django.shortcuts import HttpResponse
@@ -6,49 +8,30 @@ from django.conf import settings
 from django.http import HttpResponseBadRequest
 
 from .convert import Converter
+from .forms import RasterizeForm
 
 
 @method_decorator(csrf_exempt, name='dispatch')
-class Rasterize(View):
+class Rasterize(FormView):
 
-    FORMATS = ('png', 'pdf')
+    http_method_names = ('post', )
+    form_class = RasterizeForm
 
-    def is_valid(self, request):
-        # TODO - change into a form
-        msg = None
+    def form_invalid(self, form):
+        return HttpResponseBadRequest(json.dumps(form.errors))
 
-        # ensure payload is valid
-        format = request.POST.get('format')
-        if format not in self.FORMATS:
-            msg = 'Invalid rasterization format; must be one of [{}]'.format(
-                ', '.join(self.FORMATS))
+    def form_valid(self, form):
+        data = form.cleaned_data
+        format_ = data['format']
 
-        content = request.POST.get('content')
-        width = request.POST.get('width')
-        height = request.POST.get('height')
-        if any([content is None, width is None, height is None]):
-            msg = 'Content, width, and height are required.'
-
-        return msg
-
-    def post(self, request):
-        # check input arguments
-        msg = self.is_valid(request)
-        if msg:
-            return HttpResponseBadRequest(msg)
-
-        # convert html
-        format = request.POST['format']
-        content = request.POST['content']
-        width = request.POST['width']
-        height = request.POST['height']
-        protocol = 'https' if request.is_secure() else 'http'
+        protocol = 'https' if self.request.is_secure() else 'http'
         static_path = '{}://{}{}'.format(
-            protocol, request.META['HTTP_HOST'], settings.STATIC_URL)
-        converter = Converter(static_path, format, content, width, height)
+            protocol, self.request.META['HTTP_HOST'], settings.STATIC_URL)
+        converter = Converter(
+            static_path, format_, data['content'],
+            data['width'], data['height'])
         image = converter.convert()
 
-        # return response as downloadable file
-        response = HttpResponse(image, content_type='application/{}'.format(format))
-        response['Content-Disposition'] = 'attachment; filename="download.{}"'.format(format)
+        response = HttpResponse(image, content_type='application/{}'.format(format_))
+        response['Content-Disposition'] = 'attachment; filename="download.{}"'.format(format_)
         return response

--- a/project/phantom/views.py
+++ b/project/phantom/views.py
@@ -1,0 +1,54 @@
+from django.views.generic import View
+from django.views.decorators.csrf import csrf_exempt
+from django.utils.decorators import method_decorator
+from django.shortcuts import HttpResponse
+from django.conf import settings
+from django.http import HttpResponseBadRequest
+
+from .convert import Converter
+
+
+@method_decorator(csrf_exempt, name='dispatch')
+class Rasterize(View):
+
+    FORMATS = ('png', 'pdf')
+
+    def is_valid(self, request):
+        # TODO - change into a form
+        msg = None
+
+        # ensure payload is valid
+        format = request.POST.get('format')
+        if format not in self.FORMATS:
+            msg = 'Invalid rasterization format; must be one of [{}]'.format(
+                ', '.join(self.FORMATS))
+
+        content = request.POST.get('content')
+        width = request.POST.get('width')
+        height = request.POST.get('height')
+        if any([content is None, width is None, height is None]):
+            msg = 'Content, width, and height are required.'
+
+        return msg
+
+    def post(self, request):
+        # check input arguments
+        msg = self.is_valid(request)
+        if msg:
+            return HttpResponseBadRequest(msg)
+
+        # convert html
+        format = request.POST['format']
+        content = request.POST['content']
+        width = request.POST['width']
+        height = request.POST['height']
+        protocol = 'https' if request.is_secure() else 'http'
+        static_path = '{}://{}{}'.format(
+            protocol, request.META['HTTP_HOST'], settings.STATIC_URL)
+        converter = Converter(static_path, format, content, width, height)
+        image = converter.convert()
+
+        # return response as downloadable file
+        response = HttpResponse(image, content_type='application/{}'.format(format))
+        response['Content-Disposition'] = 'attachment; filename="download.{}"'.format(format)
+        return response


### PR DESCRIPTION
A reviewer requested the ability to download static images of the visualizations created in ORIO. This PR enables the ability for a user to pass a currently rendered image from the client to the server and render using the [PhantomJS](http://phantomjs.org/) headless browser, returning a PNG or PDF image of the result.

A few tweaks are required; namely svg overflow is cropped using PhantomJS (but not when using google chrome) - a little refactoring of the SVGs is therefore required.

To install PhantomJS (on Mac): ``brew install phantomjs``. 